### PR TITLE
Force title to be Playn.be

### DIFF
--- a/index.html
+++ b/index.html
@@ -406,7 +406,13 @@
 		<script src="https://cdn.rawgit.com/pbutenee/pbutenee.github.io/master/assets/js/placeholder.js"></script>
         <![endif]-->
 
-    </body>
+		<script>
+			$(document).ready(function () {
+				document.title = "Playn.be";
+			});
+		</script>
+
+	</body>
 
 </html>
 


### PR DESCRIPTION
This little piece of code forces the title of the window to alter after the page is loaded. Bit forceful, but handy if something else forces your page title to be different. 
